### PR TITLE
Add Clojure Tic Tac Toe game

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,15 @@
 # smartypants
+
+A simple functional Clojure implementation of Tic Tac Toe where you play against the computer.
+
+## Running the game
+
+```bash
+clojure -M -m tictactoe.core
+```
+
+## Running the tests
+
+```bash
+clojure -M:test
+```

--- a/deps.edn
+++ b/deps.edn
@@ -1,0 +1,3 @@
+{:paths ["src"]
+ :aliases {:test {:extra-paths ["test"]
+                  :main-opts ["-m" "clojure.test" "tictactoe.core-test"]}}}

--- a/src/tictactoe/core.clj
+++ b/src/tictactoe/core.clj
@@ -1,0 +1,97 @@
+(ns tictactoe.core
+  (:gen-class))
+
+(def initial-board (vec (repeat 9 nil)))
+
+(def winning-lines
+  [[0 1 2] [3 4 5] [6 7 8]
+   [0 3 6] [1 4 7] [2 5 8]
+   [0 4 8] [2 4 6]])
+
+(defn winner [board]
+  (some (fn [[a b c]]
+          (let [va (board a) vb (board b) vc (board c)]
+            (when (and va (= va vb vc)) va)))
+        winning-lines))
+
+(defn board-full? [board]
+  (every? some? board))
+
+(defn game-over? [board]
+  (or (winner board) (board-full? board)))
+
+(defn score [board]
+  (case (winner board)
+    :o 1
+    :x -1
+    0))
+
+(defn available-moves [board]
+  (keep-indexed (fn [i v] (when (nil? v) i)) board))
+
+(defn make-move [board idx player]
+  (assoc board idx player))
+
+(defn minimax [board player]
+  (if (game-over? board)
+    {:score (score board)}
+    (let [next-player (if (= player :x) :o :x)
+          moves (available-moves board)
+          results (map (fn [m]
+                         (let [new-board (make-move board m player)
+                               {:keys [score]} (minimax new-board next-player)]
+                           {:move m :score score}))
+                       moves)]
+      (if (= player :o)
+        (apply max-key :score results)
+        (apply min-key :score results)))))
+
+(defn best-move [board]
+  (:move (minimax board :o)))
+
+(defn render-cell [i v]
+  (str (case v
+         :x "X"
+         :o "O"
+         (inc i))))
+
+(defn print-board [board]
+  (println)
+  (doseq [row (partition 3 (map-indexed render-cell board))]
+    (println (clojure.string/join " | " row)))
+  (println))
+
+(defn read-move [board]
+  (println "Your move (1-9):")
+  (let [input (try (Integer/parseInt (read-line)) (catch Exception _ 0))
+        idx (dec input)]
+    (if (and (<= 0 idx 8) (nil? (board idx)))
+      idx
+      (do (println "Invalid move. Try again.")
+          (recur board)))))
+
+(defn human-turn [board]
+  (let [idx (read-move board)]
+    (make-move board idx :x)))
+
+(defn computer-turn [board]
+  (println "Computer's move:")
+  (let [idx (best-move board)]
+    (println (inc idx))
+    (make-move board idx :o)))
+
+(defn game-loop [board player]
+  (print-board board)
+  (if-let [w (winner board)]
+    (println (str (clojure.string/upper-case (name w)) " wins!"))
+    (if (board-full? board)
+      (println "Draw!")
+      (recur
+       (case player
+         :x (computer-turn board)
+         :o (human-turn board))
+       (if (= player :x) :o :x)))))
+
+(defn -main [& _]
+  (println "Welcome to Tic Tac Toe!")
+  (game-loop initial-board :o))

--- a/test/tictactoe/core_test.clj
+++ b/test/tictactoe/core_test.clj
@@ -1,0 +1,12 @@
+(ns tictactoe.core-test
+  (:require [clojure.test :refer :all]
+            [tictactoe.core :as core]))
+
+(deftest winner-detection
+  (is (= :x (core/winner [:x :x :x nil nil nil nil nil nil])))
+  (is (= :o (core/winner [:x nil nil :o :o :o nil nil nil])))
+  (is (nil? (core/winner [nil nil nil nil nil nil nil nil nil]))))
+
+(deftest best-move-wins
+  (is (= 2 (core/best-move [:o :o nil :x :x nil nil nil nil])))
+  (is (= 2 (core/best-move [:x :x nil nil :o nil nil nil nil]))))


### PR DESCRIPTION
## Summary
- implement functional Tic Tac Toe game with minimax AI opponent
- add tests for winner detection and AI move selection
- document how to run the game and tests

## Testing
- `java -cp /usr/share/java/clojure-1.11.1.jar:src:test clojure.main -e "(require 'tictactoe.core-test) (clojure.test/run-tests 'tictactoe.core-test)"`


------
https://chatgpt.com/codex/tasks/task_e_68920c137df08323ae2c94c25535b2ec